### PR TITLE
Fixed environment variable usage syntax bug

### DIFF
--- a/WebsiteArchiver/Archiver.cs
+++ b/WebsiteArchiver/Archiver.cs
@@ -69,7 +69,7 @@ namespace WebsiteArchiver
                 HttpClient client = new();
 
                 using var stream = await client.GetStreamAsync(
-                    $"{Environment.GetEnvironmentVariable("DOMAIN")stylesheet.Attributes["href"].Value}"
+                    $"{Environment.GetEnvironmentVariable("DOMAIN")}{stylesheet.Attributes["href"].Value}"
                 );
 
                 StreamReader reader = new StreamReader(stream);


### PR DESCRIPTION
Fix for a syntax error when concatenating a string containing an environment variable and another variable reference, which was causing build failures.